### PR TITLE
NGSTACK-997 upgrade bundle to ibexa version 5

### DIFF
--- a/.github/workflows/coding_standards.yml
+++ b/.github/workflows/coding_standards.yml
@@ -14,6 +14,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: OskarStark/php-cs-fixer-ga@master
+      - uses: docker://oskarstark/php-cs-fixer-ga
         with:
           args: --diff --dry-run

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,15 +15,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1']
-        symfony: ['~5.4.0']
+        php: ['8.3']
+        symfony: ['~7.3.0']
         phpunit: ['phpunit.xml']
         deps: ['normal']
-        include:
-          - php: '7.4'
-            symfony: '~5.4.0'
-            phpunit: 'phpunit.xml'
-            deps: 'low'
 
     steps:
       - uses: actions/checkout@v2
@@ -37,6 +32,7 @@ jobs:
 
       # Install Flex as a global dependency to enable usage of extra.symfony.require
       # while keeping Flex recipes from applying
+      - run: composer global config --no-plugins allow-plugins.symfony/flex true
       - run: composer global require --no-scripts symfony/flex
 
       - run: composer config extra.symfony.require ${{ matrix.symfony }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.phar
 composer.lock
 .php-cs-fixer.cache
 .phpunit.result.cache
+.phpunit.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -21,6 +21,7 @@ return (new PhpCsFixer\Config())
         'single_line_comment_style' => false,
         'visibility_required' => ['elements' => ['property', 'method', 'const']],
         'yoda_style' => false,
+        'fully_qualified_strict_types' => false,
 
         // Additional rules
         'date_time_immutable' => true,

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ netgen_site_blog:
         allowed_siteaccess: cro
 ```
 
+```php
+// if using PHP attributes
+#[Route(path: '/home', defaults: ['allowed_siteaccess' => 'cro'], methods: ['GET'])]
+```
+
 or
 
 ```yml
@@ -41,6 +46,11 @@ As a special case, you can use `_default` keyword to signal that the route is al
 ```yml
 defaults:
     allowed_siteaccess: [cro, _default]
+```
+
+```php
+// if using PHP attributes
+#[Route(path: '/home', defaults: ['allowed_siteaccess' => ['cro', '_default']], methods: ['GET'])]
 ```
 
 If the route is not available in current siteaccess, a 404 Not Found response will be returned.

--- a/bundle/EventListener/RequestListener.php
+++ b/bundle/EventListener/RequestListener.php
@@ -10,18 +10,16 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
+
 use function is_array;
 
 final class RequestListener implements EventSubscriberInterface
 {
-    public const ALLOWED_SITEACCESSES_KEY = 'allowed_siteaccess';
+    public const string ALLOWED_SITEACCESSES_KEY = 'allowed_siteaccess';
 
-    private MatcherInterface $matcher;
-
-    public function __construct(MatcherInterface $matcher)
-    {
-        $this->matcher = $matcher;
-    }
+    public function __construct(
+        private readonly MatcherInterface $matcher,
+    ) {}
 
     public static function getSubscribedEvents(): array
     {

--- a/bundle/EventListener/RequestListener.php
+++ b/bundle/EventListener/RequestListener.php
@@ -9,7 +9,6 @@ use Netgen\Bundle\SiteAccessRoutesBundle\Matcher\MatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use function is_array;
 
@@ -37,7 +36,7 @@ final class RequestListener implements EventSubscriberInterface
      */
     public function onKernelRequest(RequestEvent $event): void
     {
-        if ($event->getRequestType() !== HttpKernelInterface::MASTER_REQUEST) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/bundle/Matcher/Matcher.php
+++ b/bundle/Matcher/Matcher.php
@@ -9,17 +9,11 @@ use Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Voter\VoterInterface;
 final class Matcher implements MatcherInterface
 {
     /**
-     * @var \Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Voter\VoterInterface[]
+     * @param VoterInterface[] $voters
      */
-    private array $voters;
-
-    /**
-     * @param \Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Voter\VoterInterface[] $voters
-     */
-    public function __construct(array $voters)
-    {
-        $this->voters = $voters;
-    }
+    public function __construct(
+        private readonly array $voters,
+    ) {}
 
     /**
      * Returns if provided siteaccess is allowed based on passed route config.

--- a/bundle/Matcher/Matcher.php
+++ b/bundle/Matcher/Matcher.php
@@ -9,7 +9,7 @@ use Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Voter\VoterInterface;
 final class Matcher implements MatcherInterface
 {
     /**
-     * @param VoterInterface[] $voters
+     * @param \Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Voter\VoterInterface[] $voters
      */
     public function __construct(
         private readonly array $voters,

--- a/bundle/Matcher/Voter/DefaultSiteAccessVoter.php
+++ b/bundle/Matcher/Voter/DefaultSiteAccessVoter.php
@@ -8,14 +8,11 @@ use function in_array;
 
 final class DefaultSiteAccessVoter implements VoterInterface
 {
-    public const DEFAULT_KEY = '_default';
+    public const string DEFAULT_KEY = '_default';
 
-    private string $defaultSiteAccess;
-
-    public function __construct(string $defaultSiteAccess)
-    {
-        $this->defaultSiteAccess = $defaultSiteAccess;
-    }
+    public function __construct(
+        private readonly string $defaultSiteAccess,
+    ) {}
 
     /**
      * Returns if provided siteaccess is allowed based on passed route config.
@@ -26,7 +23,7 @@ final class DefaultSiteAccessVoter implements VoterInterface
             return VoterInterface::ABSTAIN;
         }
 
-        if (in_array(static::DEFAULT_KEY, $routeConfig, true)) {
+        if (in_array(self::DEFAULT_KEY, $routeConfig, true)) {
             return true;
         }
 

--- a/bundle/Matcher/Voter/SiteAccessGroupVoter.php
+++ b/bundle/Matcher/Voter/SiteAccessGroupVoter.php
@@ -8,12 +8,9 @@ use function in_array;
 
 final class SiteAccessGroupVoter implements VoterInterface
 {
-    private array $groupsBySiteAccess;
-
-    public function __construct(array $groupsBySiteAccess)
-    {
-        $this->groupsBySiteAccess = $groupsBySiteAccess;
-    }
+    public function __construct(
+        private readonly array $groupsBySiteAccess,
+    ) {}
 
     /**
      * Returns if provided siteaccess is allowed based on passed route config.

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
         }
     ],
     "require": {
-        "ibexa/core": "^4.0"
+        "ibexa/core": "^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^12.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,31 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.5/phpunit.xsd"
-    backupGlobals="false"
-    bootstrap="vendor/autoload.php"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    forceCoversAnnotation="true"
-    beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutOutputDuringTests="true"
-    beStrictAboutChangesToGlobalState="true"
->
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.4/phpunit.xsd"
+        backupGlobals="false"
+        bootstrap="vendor/autoload.php"
+        colors="true"
+        beStrictAboutTestsThatDoNotTestAnything="true"
+        beStrictAboutOutputDuringTests="true"
+        beStrictAboutChangesToGlobalState="true"
+        cacheDirectory=".phpunit.cache"
+        requireCoverageMetadata="true">
     <testsuites>
         <testsuite name="Netgen\Bundle\SiteAccessRoutesBundle">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <source>
+        <include>
             <directory suffix=".php">bundle</directory>
-            <exclude>
-                <directory>bundle/DependencyInjection</directory>
-                <directory>bundle/Resources</directory>
-                <file>NetgenSiteAccessRoutesBundle.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory>bundle/DependencyInjection</directory>
+            <directory>bundle/Resources</directory>
+            <file>NetgenSiteAccessRoutesBundle.php</file>
+        </exclude>
+    </source>
 </phpunit>

--- a/tests/EventListener/RequestListenerTest.php
+++ b/tests/EventListener/RequestListenerTest.php
@@ -7,6 +7,7 @@ namespace Netgen\Bundle\SiteAccessRoutesBundle\Tests\EventListener;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
 use Netgen\Bundle\SiteAccessRoutesBundle\EventListener\RequestListener;
 use Netgen\Bundle\SiteAccessRoutesBundle\Matcher\MatcherInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -15,6 +16,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
+#[CoversClass(RequestListener::class)]
 final class RequestListenerTest extends TestCase
 {
     private MockObject $matcherMock;
@@ -28,10 +30,6 @@ final class RequestListenerTest extends TestCase
         $this->listener = new RequestListener($this->matcherMock);
     }
 
-    /**
-     * @covers \Netgen\Bundle\SiteAccessRoutesBundle\EventListener\RequestListener::__construct
-     * @covers \Netgen\Bundle\SiteAccessRoutesBundle\EventListener\RequestListener::getSubscribedEvents
-     */
     public function testGetSubscribedEvents(): void
     {
         self::assertSame(
@@ -40,9 +38,6 @@ final class RequestListenerTest extends TestCase
         );
     }
 
-    /**
-     * @covers \Netgen\Bundle\SiteAccessRoutesBundle\EventListener\RequestListener::onKernelRequest
-     */
     public function testOnKernelRequest(): void
     {
         $kernelMock = $this->createMock(HttpKernelInterface::class);
@@ -57,13 +52,10 @@ final class RequestListenerTest extends TestCase
             ->with(self::equalTo('eng'), self::equalTo(['cro']))
             ->willReturn(true);
 
-        $event = new RequestEvent($kernelMock, $request, HttpKernelInterface::MASTER_REQUEST);
+        $event = new RequestEvent($kernelMock, $request, HttpKernelInterface::MAIN_REQUEST);
         self::assertNull($this->listener->onKernelRequest($event));
     }
 
-    /**
-     * @covers \Netgen\Bundle\SiteAccessRoutesBundle\EventListener\RequestListener::onKernelRequest
-     */
     public function testOnKernelRequestWithConfigArray(): void
     {
         $kernelMock = $this->createMock(HttpKernelInterface::class);
@@ -78,13 +70,10 @@ final class RequestListenerTest extends TestCase
             ->with(self::equalTo('eng'), self::equalTo(['cro', 'eng']))
             ->willReturn(true);
 
-        $event = new RequestEvent($kernelMock, $request, HttpKernelInterface::MASTER_REQUEST);
+        $event = new RequestEvent($kernelMock, $request, HttpKernelInterface::MAIN_REQUEST);
         self::assertNull($this->listener->onKernelRequest($event));
     }
 
-    /**
-     * @covers \Netgen\Bundle\SiteAccessRoutesBundle\EventListener\RequestListener::onKernelRequest
-     */
     public function testOnKernelRequestThrowsNotFoundHttpException(): void
     {
         $this->expectException(NotFoundHttpException::class);
@@ -101,13 +90,10 @@ final class RequestListenerTest extends TestCase
             ->with(self::equalTo('eng'), self::equalTo(['cro', 'eng']))
             ->willReturn(false);
 
-        $event = new RequestEvent($kernelMock, $request, HttpKernelInterface::MASTER_REQUEST);
+        $event = new RequestEvent($kernelMock, $request, HttpKernelInterface::MAIN_REQUEST);
         $this->listener->onKernelRequest($event);
     }
 
-    /**
-     * @covers \Netgen\Bundle\SiteAccessRoutesBundle\EventListener\RequestListener::onKernelRequest
-     */
     public function testOnKernelRequestInSubRequest(): void
     {
         $kernelMock = $this->createMock(HttpKernelInterface::class);
@@ -124,9 +110,6 @@ final class RequestListenerTest extends TestCase
         self::assertNull($this->listener->onKernelRequest($event));
     }
 
-    /**
-     * @covers \Netgen\Bundle\SiteAccessRoutesBundle\EventListener\RequestListener::onKernelRequest
-     */
     public function testOnKernelRequestWithNoSiteAccess(): void
     {
         $kernelMock = $this->createMock(HttpKernelInterface::class);
@@ -138,13 +121,10 @@ final class RequestListenerTest extends TestCase
             ->expects(self::never())
             ->method('isAllowed');
 
-        $event = new RequestEvent($kernelMock, $request, HttpKernelInterface::MASTER_REQUEST);
+        $event = new RequestEvent($kernelMock, $request, HttpKernelInterface::MAIN_REQUEST);
         self::assertNull($this->listener->onKernelRequest($event));
     }
 
-    /**
-     * @covers \Netgen\Bundle\SiteAccessRoutesBundle\EventListener\RequestListener::onKernelRequest
-     */
     public function testOnKernelRequestWithNoConfig(): void
     {
         $kernelMock = $this->createMock(HttpKernelInterface::class);
@@ -156,13 +136,10 @@ final class RequestListenerTest extends TestCase
             ->expects(self::never())
             ->method('isAllowed');
 
-        $event = new RequestEvent($kernelMock, $request, HttpKernelInterface::MASTER_REQUEST);
+        $event = new RequestEvent($kernelMock, $request, HttpKernelInterface::MAIN_REQUEST);
         self::assertNull($this->listener->onKernelRequest($event));
     }
 
-    /**
-     * @covers \Netgen\Bundle\SiteAccessRoutesBundle\EventListener\RequestListener::onKernelRequest
-     */
     public function testOnKernelRequestWithEmptyConfig(): void
     {
         $kernelMock = $this->createMock(HttpKernelInterface::class);
@@ -175,7 +152,7 @@ final class RequestListenerTest extends TestCase
             ->expects(self::never())
             ->method('isAllowed');
 
-        $event = new RequestEvent($kernelMock, $request, HttpKernelInterface::MASTER_REQUEST);
+        $event = new RequestEvent($kernelMock, $request, HttpKernelInterface::MAIN_REQUEST);
         self::assertNull($this->listener->onKernelRequest($event));
     }
 }

--- a/tests/Matcher/MatcherIntegrationTest.php
+++ b/tests/Matcher/MatcherIntegrationTest.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace Netgen\Bundle\SiteAccessRoutesBundle\Tests\Matcher;
 
 use Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Matcher;
+use Netgen\Bundle\SiteAccessRoutesBundle\Matcher\MatcherInterface;
 use Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Voter;
+use PHPUnit\Framework\Attributes\CoversClassesThatImplementInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClassesThatImplementInterface(MatcherInterface::class)]
 final class MatcherIntegrationTest extends TestCase
 {
     private Matcher $matcher;
@@ -29,18 +33,13 @@ final class MatcherIntegrationTest extends TestCase
         );
     }
 
-    /**
-     * @covers \Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Matcher::__construct
-     * @covers \Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Matcher::isAllowed
-     *
-     * @dataProvider isAllowedProvider
-     */
+    #[DataProvider('provideIsAllowedCases')]
     public function testIsAllowed(string $siteAccess, array $routeConfig, bool $isAllowed): void
     {
         self::assertSame($isAllowed, $this->matcher->isAllowed($siteAccess, $routeConfig));
     }
 
-    public function isAllowedProvider(): array
+    public static function provideIsAllowedCases(): iterable
     {
         return [
             ['eng', ['eng'], true],

--- a/tests/Matcher/MatcherTest.php
+++ b/tests/Matcher/MatcherTest.php
@@ -17,7 +17,7 @@ final class MatcherTest extends TestCase
     private Matcher $matcher;
 
     /**
-     * @var MockObject[]
+     * @var \PHPUnit\Framework\MockObject\MockObject[]
      */
     private array $voterMocks;
 

--- a/tests/Matcher/MatcherTest.php
+++ b/tests/Matcher/MatcherTest.php
@@ -8,7 +8,6 @@ use Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Matcher;
 use Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Voter\VoterInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(Matcher::class)]

--- a/tests/Matcher/MatcherTest.php
+++ b/tests/Matcher/MatcherTest.php
@@ -6,14 +6,18 @@ namespace Netgen\Bundle\SiteAccessRoutesBundle\Tests\Matcher;
 
 use Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Matcher;
 use Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Voter\VoterInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(Matcher::class)]
 final class MatcherTest extends TestCase
 {
     private Matcher $matcher;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject[]
+     * @var MockObject[]
      */
     private array $voterMocks;
 
@@ -28,17 +32,11 @@ final class MatcherTest extends TestCase
         $this->matcher = new Matcher($this->voterMocks);
     }
 
-    /**
-     * @covers \Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Matcher::__construct
-     * @covers \Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Matcher::isAllowed
-     *
-     * @dataProvider isAllowedProvider
-     */
+    #[DataProvider('provideIsAllowedCases')]
     public function testIsAllowed(array $voterResults, bool $isAllowed): void
     {
         foreach ($this->voterMocks as $index => $voter) {
             $voter
-                ->expects(self::any())
                 ->method('vote')
                 ->willReturn($voterResults[$index]);
         }
@@ -46,7 +44,7 @@ final class MatcherTest extends TestCase
         self::assertSame($isAllowed, $this->matcher->isAllowed('cro', []));
     }
 
-    public function isAllowedProvider(): array
+    public static function provideIsAllowedCases(): iterable
     {
         return [
             [[true, true, true], true],

--- a/tests/Matcher/Voter/DefaultSiteAccessVoterTest.php
+++ b/tests/Matcher/Voter/DefaultSiteAccessVoterTest.php
@@ -6,8 +6,11 @@ namespace Netgen\Bundle\SiteAccessRoutesBundle\Tests\Matcher\Voter;
 
 use Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Voter\DefaultSiteAccessVoter;
 use Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Voter\VoterInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(DefaultSiteAccessVoter::class)]
 final class DefaultSiteAccessVoterTest extends TestCase
 {
     private DefaultSiteAccessVoter $voter;
@@ -17,18 +20,13 @@ final class DefaultSiteAccessVoterTest extends TestCase
         $this->voter = new DefaultSiteAccessVoter('eng');
     }
 
-    /**
-     * @covers \Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Voter\DefaultSiteAccessVoter::__construct
-     * @covers \Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Voter\DefaultSiteAccessVoter::vote
-     *
-     * @dataProvider voteProvider
-     */
+    #[DataProvider('provideVoteCases')]
     public function testVote(string $siteAccess, array $groupConfig, ?bool $vote): void
     {
         self::assertSame($vote, $this->voter->vote($siteAccess, $groupConfig));
     }
 
-    public function voteProvider(): array
+    public static function provideVoteCases(): iterable
     {
         return [
             ['cro', ['_default'], VoterInterface::ABSTAIN],

--- a/tests/Matcher/Voter/SiteAccessGroupVoterTest.php
+++ b/tests/Matcher/Voter/SiteAccessGroupVoterTest.php
@@ -6,8 +6,11 @@ namespace Netgen\Bundle\SiteAccessRoutesBundle\Tests\Matcher\Voter;
 
 use Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Voter\SiteAccessGroupVoter;
 use Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Voter\VoterInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(SiteAccessGroupVoter::class)]
 final class SiteAccessGroupVoterTest extends TestCase
 {
     private SiteAccessGroupVoter $voter;
@@ -23,18 +26,13 @@ final class SiteAccessGroupVoterTest extends TestCase
         );
     }
 
-    /**
-     * @covers \Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Voter\SiteAccessGroupVoter::__construct
-     * @covers \Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Voter\SiteAccessGroupVoter::vote
-     *
-     * @dataProvider voteProvider
-     */
+    #[DataProvider('provideVoteCases')]
     public function testVote(string $siteAccess, array $groupConfig, ?bool $vote): void
     {
         self::assertSame($vote, $this->voter->vote($siteAccess, $groupConfig));
     }
 
-    public function voteProvider(): array
+    public static function provideVoteCases(): iterable
     {
         return [
             ['cro', ['cro', 'backend'], VoterInterface::ABSTAIN],

--- a/tests/Matcher/Voter/SiteAccessVoterTest.php
+++ b/tests/Matcher/Voter/SiteAccessVoterTest.php
@@ -6,8 +6,11 @@ namespace Netgen\Bundle\SiteAccessRoutesBundle\Tests\Matcher\Voter;
 
 use Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Voter\SiteAccessVoter;
 use Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Voter\VoterInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(SiteAccessVoter::class)]
 final class SiteAccessVoterTest extends TestCase
 {
     private SiteAccessVoter $voter;
@@ -17,17 +20,13 @@ final class SiteAccessVoterTest extends TestCase
         $this->voter = new SiteAccessVoter();
     }
 
-    /**
-     * @covers \Netgen\Bundle\SiteAccessRoutesBundle\Matcher\Voter\SiteAccessVoter::vote
-     *
-     * @dataProvider voteProvider
-     */
+    #[DataProvider('provideVoteCases')]
     public function testVote(string $siteAccess, array $groupConfig, ?bool $vote): void
     {
         self::assertSame($vote, $this->voter->vote($siteAccess, $groupConfig));
     }
 
-    public function voteProvider(): array
+    public static function provideVoteCases(): iterable
     {
         return [
             ['cro', ['cro', 'eng'], true],


### PR DESCRIPTION
Upgraded bundle to Ibexa version 5. 

Updated `README.md` file with examples for PHP attributes. Fixed all tests and updated the bundle to use constructor promotion in classes. 

Updated GitHub workflow for test to use PHP 8.3 and Symfony 7.3